### PR TITLE
Fix ComInterface usage

### DIFF
--- a/src/interop.rs
+++ b/src/interop.rs
@@ -9,13 +9,14 @@ use crate::windows::{
 };
 
 #[repr(C)]
-struct abi_ICompositorDesktopInterop {
+pub struct abi_ICompositorDesktopInterop {
     __base : [usize; 3],
     create_desktop_window_target: extern "system" fn(winrt::RawPtr, *mut c_void, i32, *mut winrt::RawPtr) -> winrt::ErrorCode,
     ensure_on_thread: extern "system" fn(winrt::RawPtr, u32) -> winrt::ErrorCode,
 }
 
 unsafe impl winrt::ComInterface for CompositorDesktopInterop {
+    type VTable = abi_ICompositorDesktopInterop;
     const GUID: winrt::Guid = winrt::Guid::from_values(
         702976506, 17767, 19914, [179, 25, 208, 242, 7, 235, 104, 7]
     );


### PR DESCRIPTION
The `ComInterface` trait now has a `VTable` type requirement.