### PR TITLE
Use sharp borders for rectangular shapes

### DIFF
--- a/src/minesweeper.rs
+++ b/src/minesweeper.rs
@@ -75,6 +75,7 @@ impl Minesweeper {
 
         root.set_relative_size_adjustment(Vector2 { x: 1.0, y: 1.0 })?;
         root.set_brush(compositor.create_color_brush_with_color(Colors::white()?)?)?;
+        root.set_border_mode(CompositionBorderMode::Hard)?;
         parent_visual.children()?.insert_at_top(&root)?;
 
         let tile_size = Vector2 { x: 25.0, y: 25.0 };
@@ -97,7 +98,6 @@ impl Minesweeper {
         nine_grid_brush.set_is_center_hollow(true)?;
         nine_grid_brush.set_source(color_brush)?;
         selection_visual.set_brush(nine_grid_brush)?;
-        selection_visual.set_border_mode(CompositionBorderMode::Hard)?;
         selection_visual.set_offset(Vector3::from_vector2(&margin * -1.0, 0.0))?;
         selection_visual.set_is_visible(false)?;
         selection_visual.set_size(&tile_size + &margin * 2.0)?;
@@ -264,7 +264,6 @@ impl Minesweeper {
                     self.compositor
                         .create_color_brush_with_color(Colors::blue()?)?,
                 )?;
-                visual.set_border_mode(CompositionBorderMode::Hard)?;
 
                 self.game_board.children()?.insert_at_top(&visual)?;
                 self.tiles.push(visual);

--- a/src/minesweeper.rs
+++ b/src/minesweeper.rs
@@ -6,9 +6,9 @@ use crate::windows::{
     },
     ui::{
         composition::{
-            AnimationIterationBehavior, CompositionBatchTypes, CompositionColorBrush,
-            CompositionGeometry, CompositionShape, CompositionSpriteShape, Compositor,
-            ContainerVisual, SpriteVisual,
+            AnimationIterationBehavior, CompositionBatchTypes, CompositionBorderMode,
+            CompositionColorBrush, CompositionGeometry, CompositionShape, CompositionSpriteShape,
+            Compositor, ContainerVisual, SpriteVisual,
         },
         Colors,
     },
@@ -97,6 +97,7 @@ impl Minesweeper {
         nine_grid_brush.set_is_center_hollow(true)?;
         nine_grid_brush.set_source(color_brush)?;
         selection_visual.set_brush(nine_grid_brush)?;
+        selection_visual.set_border_mode(CompositionBorderMode::Hard)?;
         selection_visual.set_offset(Vector3::from_vector2(&margin * -1.0, 0.0))?;
         selection_visual.set_is_visible(false)?;
         selection_visual.set_size(&tile_size + &margin * 2.0)?;
@@ -263,6 +264,7 @@ impl Minesweeper {
                     self.compositor
                         .create_color_brush_with_color(Colors::blue()?)?,
                 )?;
+                visual.set_border_mode(CompositionBorderMode::Hard)?;
 
                 self.game_board.children()?.insert_at_top(&visual)?;
                 self.tiles.push(visual);
@@ -371,6 +373,7 @@ impl Minesweeper {
                 let shape_visual = self.compositor.create_shape_visual()?;
                 shape_visual.set_relative_size_adjustment(Vector2 { x: 1.0, y: 1.0 })?;
                 shape_visual.shapes()?.append(shape)?;
+                shape_visual.set_border_mode(CompositionBorderMode::Soft)?;
                 visual.children()?.insert_at_top(shape_visual)?;
             }
         }


### PR DESCRIPTION
By default, shapes have an antialiased border. Right now, the squares look very fuzzy. This changes the squares and the hover indicator to not use antialiasing so they appear crisp. Antialiasing was turned on explicitly for the dots since they appear to inherit their BorderMode from the squares.

![Sharp](https://user-images.githubusercontent.com/18747724/80749503-866a7b00-8af4-11ea-8562-cfb2eb96e180.png)