### PR TITLE
Split game logic from UI

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "(Windows) Launch",
+            "type": "cppvsdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/target/debug/minesweeper-rs.exe",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "externalConsole": false
+        }
+    ]
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,6 @@ winit = "0.22.0"
 raw-window-handle = "0.3.3"
 winrt = { git = "https://github.com/microsoft/winrt-rs" }
 rand = "0.7.3"
+
+[features]
+show-mines = []

--- a/src/comp_assets.rs
+++ b/src/comp_assets.rs
@@ -1,0 +1,531 @@
+use crate::minesweeper::MineState;
+use crate::windows::{
+    foundation::{
+        numerics::Vector2,
+    },
+    ui::{
+        composition::{
+            CompositionColorBrush, CompositionGeometry, CompositionShape, CompositionSpriteShape,
+            Compositor,
+        },
+        Colors,
+    },
+};
+use std::collections::HashMap;
+use winrt::TryInto;
+
+fn get_dot_shape(
+    compositor: &Compositor,
+    geometry: &CompositionGeometry,
+    brush: &CompositionColorBrush,
+    offset: Vector2,
+) -> winrt::Result<CompositionSpriteShape> {
+    let shape = compositor
+        .create_sprite_shape_with_geometry(geometry)?;
+    shape.set_fill_brush(brush)?;
+    shape.set_offset(offset)?;
+    Ok(shape)
+}
+
+pub struct CompAssets {
+    mine_brush: CompositionColorBrush,
+    mine_state_brushes: HashMap<MineState, CompositionColorBrush>,
+    mine_count_background_brushes: HashMap<i32, CompositionColorBrush>,
+    mine_count_shapes: HashMap<i32, CompositionShape>,
+}
+
+impl CompAssets {
+    pub fn new(compositor: &Compositor, tile_size: &Vector2) -> winrt::Result<Self> {
+        let mine_brush = compositor.create_color_brush_with_color(Colors::red()?)?;
+
+        let mut result = Self {
+            mine_brush: mine_brush,
+            mine_state_brushes: HashMap::new(),
+            mine_count_background_brushes: HashMap::new(),
+            mine_count_shapes: HashMap::new(),
+        };
+
+        result.generate_assets(compositor, tile_size)?;
+
+        Ok(result)
+    }
+
+    pub fn get_mine_brush(&self) -> CompositionColorBrush {
+        self.mine_brush.clone()
+    }
+
+    pub fn get_shape_from_mine_count(&self, count: i32) -> CompositionShape {
+        self.mine_count_shapes.get(&count).unwrap().clone()
+    }
+
+    pub fn get_color_brush_from_mine_state(&self, state: MineState) -> CompositionColorBrush {
+        self.mine_state_brushes.get(&state).unwrap().clone()
+    }
+
+    pub fn get_color_brush_from_mine_count(&self, count: i32) -> CompositionColorBrush {
+        self.mine_count_background_brushes
+            .get(&count)
+            .unwrap()
+            .clone()
+    }
+
+    fn generate_assets(&mut self, compositor: &Compositor, tile_size: &Vector2) -> winrt::Result<()> {
+        self.mine_state_brushes.clear();
+        self.mine_state_brushes.insert(
+            MineState::Empty,
+            compositor
+                .create_color_brush_with_color(Colors::blue()?)?,
+        );
+        self.mine_state_brushes.insert(
+            MineState::Flag,
+            compositor
+                .create_color_brush_with_color(Colors::orange()?)?,
+        );
+        self.mine_state_brushes.insert(
+            MineState::Question,
+            compositor
+                .create_color_brush_with_color(Colors::lime_green()?)?,
+        );
+
+        self.mine_count_background_brushes.clear();
+        self.mine_count_background_brushes.insert(
+            1,
+            compositor
+                .create_color_brush_with_color(Colors::light_blue()?)?,
+        );
+        self.mine_count_background_brushes.insert(
+            2,
+            compositor
+                .create_color_brush_with_color(Colors::light_green()?)?,
+        );
+        self.mine_count_background_brushes.insert(
+            3,
+            compositor
+                .create_color_brush_with_color(Colors::light_salmon()?)?,
+        );
+        self.mine_count_background_brushes.insert(
+            4,
+            compositor
+                .create_color_brush_with_color(Colors::light_steel_blue()?)?,
+        );
+        self.mine_count_background_brushes.insert(
+            5,
+            compositor
+                .create_color_brush_with_color(Colors::medium_purple()?)?,
+        );
+        self.mine_count_background_brushes.insert(
+            6,
+            compositor
+                .create_color_brush_with_color(Colors::light_cyan()?)?,
+        );
+        self.mine_count_background_brushes.insert(
+            7,
+            compositor
+                .create_color_brush_with_color(Colors::maroon()?)?,
+        );
+        self.mine_count_background_brushes.insert(
+            8,
+            compositor
+                .create_color_brush_with_color(Colors::dark_sea_green()?)?,
+        );
+        self.mine_count_background_brushes.insert(
+            0,
+            compositor
+                .create_color_brush_with_color(Colors::white_smoke()?)?,
+        );
+
+        self.mine_count_shapes.clear();
+        let circle_geometry = compositor.create_ellipse_geometry()?;
+        circle_geometry.set_radius(tile_size / 12.0)?;
+        let circle_geometry: CompositionGeometry = circle_geometry.try_into()?;
+        let dot_brush = compositor
+            .create_color_brush_with_color(Colors::black()?)?;
+
+        // 1
+        {
+            let container_shape = compositor.create_container_shape()?;
+            let shapes = container_shape.shapes()?;
+            shapes.append(get_dot_shape(
+                compositor,
+                &circle_geometry,
+                &dot_brush,
+                tile_size / 2.0,
+            )?)?;
+            self.mine_count_shapes
+                .insert(1, container_shape.try_into()?);
+        }
+        // 2
+        {
+            let container_shape = compositor.create_container_shape()?;
+            let shapes = container_shape.shapes()?;
+            let third_x = tile_size.x / 3.0;
+            let half_y = tile_size.y / 2.0;
+            shapes.append(get_dot_shape(
+                compositor,
+                &circle_geometry,
+                &dot_brush,
+                Vector2 {
+                    x: third_x,
+                    y: half_y,
+                },
+            )?)?;
+            shapes.append(get_dot_shape(
+                compositor,
+                &circle_geometry,
+                &dot_brush,
+                Vector2 {
+                    x: third_x * 2.0,
+                    y: half_y,
+                },
+            )?)?;
+            self.mine_count_shapes
+                .insert(2, container_shape.try_into()?);
+        }
+        // 3
+        {
+            let container_shape = compositor.create_container_shape()?;
+            let shapes = container_shape.shapes()?;
+            let fourth_x = tile_size.x / 4.0;
+            let fourth_y = tile_size.y / 4.0;
+            shapes.append(get_dot_shape(
+                compositor,
+                &circle_geometry,
+                &dot_brush,
+                tile_size / 2.0,
+            )?)?;
+            shapes.append(get_dot_shape(
+                compositor,
+                &circle_geometry,
+                &dot_brush,
+                Vector2 {
+                    x: fourth_x,
+                    y: fourth_y * 3.0,
+                },
+            )?)?;
+            shapes.append(get_dot_shape(
+                compositor,
+                &circle_geometry,
+                &dot_brush,
+                Vector2 {
+                    x: fourth_x * 3.0,
+                    y: fourth_y,
+                },
+            )?)?;
+            self.mine_count_shapes
+                .insert(3, container_shape.try_into()?);
+        }
+        // 4
+        {
+            let container_shape = compositor.create_container_shape()?;
+            let shapes = container_shape.shapes()?;
+            let third_x = tile_size.x / 3.0;
+            let third_y = tile_size.y / 3.0;
+            shapes.append(get_dot_shape(
+                compositor,
+                &circle_geometry,
+                &dot_brush,
+                Vector2 {
+                    x: third_x,
+                    y: third_y,
+                },
+            )?)?;
+            shapes.append(get_dot_shape(
+                compositor,
+                &circle_geometry,
+                &dot_brush,
+                Vector2 {
+                    x: third_x * 2.0,
+                    y: third_y,
+                },
+            )?)?;
+            shapes.append(get_dot_shape(
+                compositor,
+                &circle_geometry,
+                &dot_brush,
+                Vector2 {
+                    x: third_x,
+                    y: third_y * 2.0,
+                },
+            )?)?;
+            shapes.append(get_dot_shape(
+                compositor,
+                &circle_geometry,
+                &dot_brush,
+                Vector2 {
+                    x: third_x * 2.0,
+                    y: third_y * 2.0,
+                },
+            )?)?;
+            self.mine_count_shapes
+                .insert(4, container_shape.try_into()?);
+        }
+        // 5
+        {
+            let container_shape = compositor.create_container_shape()?;
+            let shapes = container_shape.shapes()?;
+            let fourth_x = tile_size.x / 4.0;
+            let fourth_y = tile_size.y / 4.0;
+            shapes.append(get_dot_shape(
+                compositor,
+                &circle_geometry,
+                &dot_brush,
+                tile_size / 2.0,
+            )?)?;
+            shapes.append(get_dot_shape(
+                compositor,
+                &circle_geometry,
+                &dot_brush,
+                Vector2 {
+                    x: fourth_x,
+                    y: fourth_y * 3.0,
+                },
+            )?)?;
+            shapes.append(get_dot_shape(
+                compositor,
+                &circle_geometry,
+                &dot_brush,
+                Vector2 {
+                    x: fourth_x * 3.0,
+                    y: fourth_y,
+                },
+            )?)?;
+            shapes.append(get_dot_shape(
+                compositor,
+                &circle_geometry,
+                &dot_brush,
+                Vector2 {
+                    x: fourth_x,
+                    y: fourth_y,
+                },
+            )?)?;
+            shapes.append(get_dot_shape(
+                compositor,
+                &circle_geometry,
+                &dot_brush,
+                Vector2 {
+                    x: fourth_x * 3.0,
+                    y: fourth_y * 3.0,
+                },
+            )?)?;
+            self.mine_count_shapes
+                .insert(5, container_shape.try_into()?);
+        }
+        // 6
+        {
+            let container_shape = compositor.create_container_shape()?;
+            let shapes = container_shape.shapes()?;
+            let fourth_x = tile_size.x / 4.0;
+            let fourth_y = tile_size.y / 4.0;
+            shapes.append(get_dot_shape(
+                compositor,
+                &circle_geometry,
+                &dot_brush,
+                Vector2 {
+                    x: fourth_x,
+                    y: fourth_y * 2.0,
+                },
+            )?)?;
+            shapes.append(get_dot_shape(
+                compositor,
+                &circle_geometry,
+                &dot_brush,
+                Vector2 {
+                    x: fourth_x,
+                    y: fourth_y * 3.0,
+                },
+            )?)?;
+            shapes.append(get_dot_shape(
+                compositor,
+                &circle_geometry,
+                &dot_brush,
+                Vector2 {
+                    x: fourth_x * 3.0,
+                    y: fourth_y,
+                },
+            )?)?;
+            shapes.append(get_dot_shape(
+                compositor,
+                &circle_geometry,
+                &dot_brush,
+                Vector2 {
+                    x: fourth_x,
+                    y: fourth_y,
+                },
+            )?)?;
+            shapes.append(get_dot_shape(
+                compositor,
+                &circle_geometry,
+                &dot_brush,
+                Vector2 {
+                    x: fourth_x * 3.0,
+                    y: fourth_y * 3.0,
+                },
+            )?)?;
+            shapes.append(get_dot_shape(
+                compositor,
+                &circle_geometry,
+                &dot_brush,
+                Vector2 {
+                    x: fourth_x * 3.0,
+                    y: fourth_y * 2.0,
+                },
+            )?)?;
+            self.mine_count_shapes
+                .insert(6, container_shape.try_into()?);
+        }
+        // 7
+        {
+            let container_shape = compositor.create_container_shape()?;
+            let shapes = container_shape.shapes()?;
+            let fourth_x = tile_size.x / 4.0;
+            let fourth_y = tile_size.y / 4.0;
+            shapes.append(get_dot_shape(
+                compositor,
+                &circle_geometry,
+                &dot_brush,
+                Vector2 {
+                    x: fourth_x,
+                    y: fourth_y * 2.0,
+                },
+            )?)?;
+            shapes.append(get_dot_shape(
+                compositor,
+                &circle_geometry,
+                &dot_brush,
+                Vector2 {
+                    x: fourth_x,
+                    y: fourth_y * 3.0,
+                },
+            )?)?;
+            shapes.append(get_dot_shape(
+                compositor,
+                &circle_geometry,
+                &dot_brush,
+                Vector2 {
+                    x: fourth_x * 3.0,
+                    y: fourth_y,
+                },
+            )?)?;
+            shapes.append(get_dot_shape(
+                compositor,
+                &circle_geometry,
+                &dot_brush,
+                Vector2 {
+                    x: fourth_x,
+                    y: fourth_y,
+                },
+            )?)?;
+            shapes.append(get_dot_shape(
+                compositor,
+                &circle_geometry,
+                &dot_brush,
+                Vector2 {
+                    x: fourth_x * 3.0,
+                    y: fourth_y * 3.0,
+                },
+            )?)?;
+            shapes.append(get_dot_shape(
+                compositor,
+                &circle_geometry,
+                &dot_brush,
+                Vector2 {
+                    x: fourth_x * 3.0,
+                    y: fourth_y * 2.0,
+                },
+            )?)?;
+            shapes.append(get_dot_shape(
+                compositor,
+                &circle_geometry,
+                &dot_brush,
+                tile_size / 2.0,
+            )?)?;
+            self.mine_count_shapes
+                .insert(7, container_shape.try_into()?);
+        }
+        // 8
+        {
+            let container_shape = compositor.create_container_shape()?;
+            let shapes = container_shape.shapes()?;
+            let fourth_x = tile_size.x / 4.0;
+            let fourth_y = tile_size.y / 4.0;
+            let half_x = tile_size.x / 2.0;
+            let third_y = tile_size.y / 3.0;
+            shapes.append(get_dot_shape(
+                compositor,
+                &circle_geometry,
+                &dot_brush,
+                Vector2 {
+                    x: fourth_x,
+                    y: fourth_y * 2.0,
+                },
+            )?)?;
+            shapes.append(get_dot_shape(
+                compositor,
+                &circle_geometry,
+                &dot_brush,
+                Vector2 {
+                    x: fourth_x,
+                    y: fourth_y * 3.0,
+                },
+            )?)?;
+            shapes.append(get_dot_shape(
+                compositor,
+                &circle_geometry,
+                &dot_brush,
+                Vector2 {
+                    x: fourth_x * 3.0,
+                    y: fourth_y,
+                },
+            )?)?;
+            shapes.append(get_dot_shape(
+                compositor,
+                &circle_geometry,
+                &dot_brush,
+                Vector2 {
+                    x: fourth_x,
+                    y: fourth_y,
+                },
+            )?)?;
+            shapes.append(get_dot_shape(
+                compositor,
+                &circle_geometry,
+                &dot_brush,
+                Vector2 {
+                    x: fourth_x * 3.0,
+                    y: fourth_y * 3.0,
+                },
+            )?)?;
+            shapes.append(get_dot_shape(
+                compositor,
+                &circle_geometry,
+                &dot_brush,
+                Vector2 {
+                    x: fourth_x * 3.0,
+                    y: fourth_y * 2.0,
+                },
+            )?)?;
+            shapes.append(get_dot_shape(
+                compositor,
+                &circle_geometry,
+                &dot_brush,
+                Vector2 {
+                    x: half_x,
+                    y: third_y,
+                },
+            )?)?;
+            shapes.append(get_dot_shape(
+                compositor,
+                &circle_geometry,
+                &dot_brush,
+                Vector2 {
+                    x: half_x,
+                    y: third_y * 2.0,
+                },
+            )?)?;
+            self.mine_count_shapes
+                .insert(8, container_shape.try_into()?);
+        }
+
+        Ok(())
+    }
+}

--- a/src/comp_assets.rs
+++ b/src/comp_assets.rs
@@ -36,7 +36,7 @@ impl CompAssets {
         let mine_brush = compositor.create_color_brush_with_color(Colors::red()?)?;
 
         let mut result = Self {
-            mine_brush: mine_brush,
+            mine_brush,
             mine_state_brushes: HashMap::new(),
             mine_count_background_brushes: HashMap::new(),
             mine_count_shapes: HashMap::new(),

--- a/src/comp_assets.rs
+++ b/src/comp_assets.rs
@@ -1,8 +1,6 @@
 use crate::minesweeper::MineState;
 use crate::windows::{
-    foundation::{
-        numerics::Vector2,
-    },
+    foundation::numerics::Vector2,
     ui::{
         composition::{
             CompositionColorBrush, CompositionGeometry, CompositionShape, CompositionSpriteShape,
@@ -20,8 +18,7 @@ fn get_dot_shape(
     brush: &CompositionColorBrush,
     offset: Vector2,
 ) -> winrt::Result<CompositionSpriteShape> {
-    let shape = compositor
-        .create_sprite_shape_with_geometry(geometry)?;
+    let shape = compositor.create_sprite_shape_with_geometry(geometry)?;
     shape.set_fill_brush(brush)?;
     shape.set_offset(offset)?;
     Ok(shape)
@@ -69,77 +66,68 @@ impl CompAssets {
             .clone()
     }
 
-    fn generate_assets(&mut self, compositor: &Compositor, tile_size: &Vector2) -> winrt::Result<()> {
+    fn generate_assets(
+        &mut self,
+        compositor: &Compositor,
+        tile_size: &Vector2,
+    ) -> winrt::Result<()> {
         self.mine_state_brushes.clear();
         self.mine_state_brushes.insert(
             MineState::Empty,
-            compositor
-                .create_color_brush_with_color(Colors::blue()?)?,
+            compositor.create_color_brush_with_color(Colors::blue()?)?,
         );
         self.mine_state_brushes.insert(
             MineState::Flag,
-            compositor
-                .create_color_brush_with_color(Colors::orange()?)?,
+            compositor.create_color_brush_with_color(Colors::orange()?)?,
         );
         self.mine_state_brushes.insert(
             MineState::Question,
-            compositor
-                .create_color_brush_with_color(Colors::lime_green()?)?,
+            compositor.create_color_brush_with_color(Colors::lime_green()?)?,
         );
 
         self.mine_count_background_brushes.clear();
         self.mine_count_background_brushes.insert(
             1,
-            compositor
-                .create_color_brush_with_color(Colors::light_blue()?)?,
+            compositor.create_color_brush_with_color(Colors::light_blue()?)?,
         );
         self.mine_count_background_brushes.insert(
             2,
-            compositor
-                .create_color_brush_with_color(Colors::light_green()?)?,
+            compositor.create_color_brush_with_color(Colors::light_green()?)?,
         );
         self.mine_count_background_brushes.insert(
             3,
-            compositor
-                .create_color_brush_with_color(Colors::light_salmon()?)?,
+            compositor.create_color_brush_with_color(Colors::light_salmon()?)?,
         );
         self.mine_count_background_brushes.insert(
             4,
-            compositor
-                .create_color_brush_with_color(Colors::light_steel_blue()?)?,
+            compositor.create_color_brush_with_color(Colors::light_steel_blue()?)?,
         );
         self.mine_count_background_brushes.insert(
             5,
-            compositor
-                .create_color_brush_with_color(Colors::medium_purple()?)?,
+            compositor.create_color_brush_with_color(Colors::medium_purple()?)?,
         );
         self.mine_count_background_brushes.insert(
             6,
-            compositor
-                .create_color_brush_with_color(Colors::light_cyan()?)?,
+            compositor.create_color_brush_with_color(Colors::light_cyan()?)?,
         );
         self.mine_count_background_brushes.insert(
             7,
-            compositor
-                .create_color_brush_with_color(Colors::maroon()?)?,
+            compositor.create_color_brush_with_color(Colors::maroon()?)?,
         );
         self.mine_count_background_brushes.insert(
             8,
-            compositor
-                .create_color_brush_with_color(Colors::dark_sea_green()?)?,
+            compositor.create_color_brush_with_color(Colors::dark_sea_green()?)?,
         );
         self.mine_count_background_brushes.insert(
             0,
-            compositor
-                .create_color_brush_with_color(Colors::white_smoke()?)?,
+            compositor.create_color_brush_with_color(Colors::white_smoke()?)?,
         );
 
         self.mine_count_shapes.clear();
         let circle_geometry = compositor.create_ellipse_geometry()?;
         circle_geometry.set_radius(tile_size / 12.0)?;
         let circle_geometry: CompositionGeometry = circle_geometry.try_into()?;
-        let dot_brush = compositor
-            .create_color_brush_with_color(Colors::black()?)?;
+        let dot_brush = compositor.create_color_brush_with_color(Colors::black()?)?;
 
         // 1
         {

--- a/src/comp_ui.rs
+++ b/src/comp_ui.rs
@@ -1,0 +1,275 @@
+use crate::comp_assets::CompAssets;
+use crate::minesweeper::{MineState, IndexHelper};
+use crate::visual_grid::{VisualGrid, TileCoordinate};
+use crate::windows::{
+    foundation::{
+        numerics::{Vector2, Vector3},
+        TimeSpan,
+    },
+    graphics::SizeInt32,
+    ui::{
+        composition::{
+            AnimationIterationBehavior, CompositionBatchTypes, CompositionBorderMode,
+            Compositor, ContainerVisual, SpriteVisual,
+        },
+        Colors,
+    },
+};
+use std::collections::VecDeque;
+use std::time::Duration;
+
+pub struct CompUI {
+    compositor: Compositor,
+    _root: SpriteVisual,
+    parent_size: Vector2,
+    game_board_margin: Vector2,
+    index_helper: IndexHelper,
+
+    game_board: VisualGrid,
+    assets: CompAssets,
+
+    mine_animation_playing: bool,
+}
+
+impl CompUI {
+    pub fn new(parent_visual: &ContainerVisual, parent_size: &Vector2, grid_size_in_tiles: &SizeInt32) -> winrt::Result<Self> {
+        let compositor = parent_visual.compositor()?;
+        let root = compositor.create_sprite_visual()?;
+
+        root.set_relative_size_adjustment(Vector2 { x: 1.0, y: 1.0 })?;
+        root.set_brush(compositor.create_color_brush_with_color(Colors::white()?)?)?;
+        root.set_border_mode(CompositionBorderMode::Hard)?;
+        parent_visual.children()?.insert_at_top(&root)?;
+
+        let tile_size = Vector2 { x: 25.0, y: 25.0 };
+        let game_board = VisualGrid::new(
+            &compositor,
+            grid_size_in_tiles,
+            &tile_size,
+            &Vector2 { x: 2.5, y: 2.5 },
+        )?;
+        let game_board_margin = Vector2 { x: 100.0, y: 100.0 };
+
+        let game_board_visual = game_board.root();
+        game_board_visual.set_relative_offset_adjustment(Vector3 {
+            x: 0.5,
+            y: 0.5,
+            z: 0.0,
+        })?;
+        game_board_visual.set_anchor_point(Vector2 { x: 0.5, y: 0.5 })?;
+        root.children()?.insert_at_top(game_board_visual)?;
+
+        let selection_visual = game_board.selection_visual();
+        root.children()?.insert_at_top(selection_visual)?;
+
+        let assets = CompAssets::new(&compositor, &tile_size)?;
+
+        Ok(Self {
+            compositor: compositor,
+            _root: root,
+            parent_size: parent_size.clone(),
+            game_board_margin: game_board_margin,
+            index_helper: IndexHelper::new(grid_size_in_tiles.width, grid_size_in_tiles.height),
+
+            game_board: game_board,
+            assets: assets,
+            mine_animation_playing: false,
+        })
+    }
+
+    pub fn hit_test(&self, point: &Vector2) -> winrt::Result<Option<TileCoordinate>> {
+        let window_size = &self.parent_size;
+        let scale = self.compute_scale_factor()?;
+        let real_board_size = self.game_board.size()? * scale;
+        let real_offset = (window_size - real_board_size) / 2.0;
+
+        let point = (point - real_offset) / scale;
+        Ok(self.game_board.hit_test(&point))
+    }
+
+    pub fn resize(&mut self, new_size: &Vector2) -> winrt::Result<()> {
+        self.parent_size = new_size.clone();
+        self.update_board_scale(new_size)?;
+        Ok(())
+    }
+
+    pub fn select_tile(&mut self, tile_coordinate: Option<TileCoordinate>) -> winrt::Result<()> {
+        self.game_board.select_tile(tile_coordinate)
+    }
+
+    pub fn current_selected_tile(&self) -> Option<TileCoordinate> {
+        self.game_board.current_selected_tile()
+    }
+
+    pub fn update_tile_with_state(&self, tile_coordinate: &TileCoordinate, mine_state: MineState) -> winrt::Result<()> {
+        let visual = self
+                .game_board
+                .get_tile(tile_coordinate.x, tile_coordinate.y)
+                .unwrap();
+
+        visual.set_brush(self.assets.get_color_brush_from_mine_state(mine_state))?;
+        Ok(())
+    }
+
+    pub fn reset(&mut self, grid_size_in_tiles: &SizeInt32) -> winrt::Result<()> {
+        self.game_board.reset(grid_size_in_tiles)?;
+        self.index_helper = IndexHelper::new(grid_size_in_tiles.width, grid_size_in_tiles.height);
+
+        for visual in self.game_board.tiles_iter() {
+            visual.set_brush(self.assets.get_color_brush_from_mine_state(MineState::Empty))?;
+        }
+
+        self.update_board_scale(&self.parent_size.clone())?;
+        self.mine_animation_playing = false;
+
+        Ok(())
+    }
+
+    pub fn update_tile_as_mine(&self, tile_coordinate: &TileCoordinate) -> winrt::Result<()> {
+        let visual = self
+            .game_board
+            .get_tile(
+                tile_coordinate.x,
+                tile_coordinate.y,
+            )
+            .unwrap();
+
+        visual.set_brush(&self.assets.get_mine_brush())?;
+        Ok(())
+    }
+
+    pub fn update_tile_with_mine_count(&self, tile_coordinate: &TileCoordinate, num_mines: i32) -> winrt::Result<()> {
+        let visual = self
+            .game_board
+            .get_tile(
+                tile_coordinate.x,
+                tile_coordinate.y,
+            )
+            .unwrap();
+        visual.set_brush(self.assets.get_color_brush_from_mine_count(num_mines))?;
+
+        if num_mines > 0 {
+            let shape = self.assets.get_shape_from_mine_count(num_mines);
+            let shape_visual = self.compositor.create_shape_visual()?;
+            shape_visual.set_relative_size_adjustment(Vector2 { x: 1.0, y: 1.0 })?;
+            shape_visual.shapes()?.append(shape)?;
+            shape_visual.set_border_mode(CompositionBorderMode::Soft)?;
+            visual.children()?.insert_at_top(shape_visual)?;
+        }
+
+        Ok(())
+    }
+
+    pub fn play_mine_animations(&mut self, mut mine_indices: VecDeque<usize>, mut mines_per_ring: VecDeque<i32>) -> winrt::Result<()> {
+        // Create an animation batch so that we can know when the animations complete
+        let batch = self
+                            .compositor
+                            .create_scoped_batch(CompositionBatchTypes::Animation)?;
+
+        let animation_delay_step = Duration::from_millis(100);
+        let mut current_delay = Duration::from_millis(0);
+        let mut current_mines_count = 0;
+        while !mine_indices.is_empty() {
+            let mine_index = *mine_indices.front().unwrap();
+            self.play_mine_animation(mine_index, &TimeSpan::from(current_delay))?;
+            current_mines_count = current_mines_count + 1;
+
+            let mines_on_current_level = *mines_per_ring.front().unwrap();
+            if current_mines_count == mines_on_current_level {
+                current_mines_count = 0;
+                mines_per_ring.pop_front().unwrap();
+                current_delay = current_delay + animation_delay_step;
+            }
+            mine_indices.pop_front().unwrap();
+        }
+
+        // Subscribe to the completion event and complete the batch
+        // TODO: events
+        batch.end()?;
+
+        self.mine_animation_playing = true;
+
+        Ok(())
+    }
+
+    pub fn is_animation_playing(&self) -> bool {
+        self.mine_animation_playing
+    }
+
+    fn compute_scale_factor_from_size(&self, window_size: &Vector2) -> winrt::Result<f32> {
+        let board_size = self.game_board.size()?;
+        let board_size = board_size + &self.game_board_margin;
+
+        let window_ratio = window_size.x / window_size.y;
+        let board_ratio = board_size.x / board_size.y;
+
+        let mut scale_factor = window_size.x / board_size.x;
+        if window_ratio > board_ratio {
+            scale_factor = window_size.y / board_size.y;
+        }
+
+        Ok(scale_factor)
+    }
+
+    fn compute_scale_factor(&self) -> winrt::Result<f32> {
+        self.compute_scale_factor_from_size(&self.parent_size)
+    }
+
+    fn update_board_scale(&mut self, window_size: &Vector2) -> winrt::Result<()> {
+        let scale_factor = self.compute_scale_factor_from_size(window_size)?;
+        self.game_board.root().set_scale(Vector3 {
+            x: scale_factor,
+            y: scale_factor,
+            z: 1.0,
+        })?;
+        Ok(())
+    }
+
+    fn play_mine_animation(&self, index: usize, delay: &TimeSpan) -> winrt::Result<()> {
+        let visual = self
+            .game_board
+            .get_tile(
+                self.index_helper.compute_x_from_index(index),
+                self.index_helper.compute_y_from_index(index),
+            )
+            .unwrap();
+        // First, we need to promote the visual to the top.
+        let parent_children = visual.parent()?.children()?;
+        parent_children.remove(visual)?;
+        parent_children.insert_at_top(visual)?;
+        // Make sure the visual has the mine brush
+        visual.set_brush(&self.assets.get_mine_brush())?;
+        // Play the animation
+        let animation = self.compositor.create_vector3_key_frame_animation()?;
+        animation.insert_key_frame(
+            0.0,
+            Vector3 {
+                x: 1.0,
+                y: 1.0,
+                z: 1.0,
+            },
+        )?;
+        animation.insert_key_frame(
+            0.7,
+            Vector3 {
+                x: 2.0,
+                y: 2.0,
+                z: 1.0,
+            },
+        )?;
+        animation.insert_key_frame(
+            1.0,
+            Vector3 {
+                x: 1.0,
+                y: 1.0,
+                z: 1.0,
+            },
+        )?;
+        animation.set_duration(TimeSpan::from(Duration::from_millis(600)))?;
+        animation.set_delay_time(delay)?;
+        animation.set_iteration_behavior(AnimationIterationBehavior::Count)?;
+        animation.set_iteration_count(1)?;
+        visual.start_animation("Scale", animation)?;
+        Ok(())
+    }
+}

--- a/src/comp_ui.rs
+++ b/src/comp_ui.rs
@@ -216,10 +216,11 @@ impl CompUI {
         let window_ratio = window_size.x / window_size.y;
         let board_ratio = board_size.x / board_size.y;
 
-        let mut scale_factor = window_size.x / board_size.x;
-        if window_ratio > board_ratio {
-            scale_factor = window_size.y / board_size.y;
-        }
+        let scale_factor = if window_ratio > board_ratio {
+            window_size.y / board_size.y
+        } else {
+            window_size.x / board_size.x
+        };
 
         Ok(scale_factor)
     }

--- a/src/comp_ui.rs
+++ b/src/comp_ui.rs
@@ -69,14 +69,14 @@ impl CompUI {
         let assets = CompAssets::new(&compositor, &tile_size)?;
 
         Ok(Self {
-            compositor: compositor,
+            compositor,
             _root: root,
             parent_size: parent_size.clone(),
-            game_board_margin: game_board_margin,
+            game_board_margin,
             index_helper: IndexHelper::new(grid_size_in_tiles.width, grid_size_in_tiles.height),
 
-            game_board: game_board,
-            assets: assets,
+            game_board,
+            assets,
             mine_animation_playing: false,
         })
     }
@@ -185,13 +185,13 @@ impl CompUI {
         while !mine_indices.is_empty() {
             let mine_index = *mine_indices.front().unwrap();
             self.play_mine_animation(mine_index, &TimeSpan::from(current_delay))?;
-            current_mines_count = current_mines_count + 1;
+            current_mines_count += 1;
 
             let mines_on_current_level = *mines_per_ring.front().unwrap();
             if current_mines_count == mines_on_current_level {
                 current_mines_count = 0;
                 mines_per_ring.pop_front().unwrap();
-                current_delay = current_delay + animation_delay_step;
+                current_delay += animation_delay_step;
             }
             mine_indices.pop_front().unwrap();
         }

--- a/src/comp_ui.rs
+++ b/src/comp_ui.rs
@@ -1,6 +1,6 @@
 use crate::comp_assets::CompAssets;
-use crate::minesweeper::{MineState, IndexHelper};
-use crate::visual_grid::{VisualGrid, TileCoordinate};
+use crate::minesweeper::{IndexHelper, MineState};
+use crate::visual_grid::{TileCoordinate, VisualGrid};
 use crate::windows::{
     foundation::{
         numerics::{Vector2, Vector3},
@@ -9,8 +9,8 @@ use crate::windows::{
     graphics::SizeInt32,
     ui::{
         composition::{
-            AnimationIterationBehavior, CompositionBatchTypes, CompositionBorderMode,
-            Compositor, ContainerVisual, SpriteVisual,
+            AnimationIterationBehavior, CompositionBatchTypes, CompositionBorderMode, Compositor,
+            ContainerVisual, SpriteVisual,
         },
         Colors,
     },
@@ -32,7 +32,11 @@ pub struct CompUI {
 }
 
 impl CompUI {
-    pub fn new(parent_visual: &ContainerVisual, parent_size: &Vector2, grid_size_in_tiles: &SizeInt32) -> winrt::Result<Self> {
+    pub fn new(
+        parent_visual: &ContainerVisual,
+        parent_size: &Vector2,
+        grid_size_in_tiles: &SizeInt32,
+    ) -> winrt::Result<Self> {
         let compositor = parent_visual.compositor()?;
         let root = compositor.create_sprite_visual()?;
 
@@ -101,11 +105,15 @@ impl CompUI {
         self.game_board.current_selected_tile()
     }
 
-    pub fn update_tile_with_state(&self, tile_coordinate: &TileCoordinate, mine_state: MineState) -> winrt::Result<()> {
+    pub fn update_tile_with_state(
+        &self,
+        tile_coordinate: &TileCoordinate,
+        mine_state: MineState,
+    ) -> winrt::Result<()> {
         let visual = self
-                .game_board
-                .get_tile(tile_coordinate.x, tile_coordinate.y)
-                .unwrap();
+            .game_board
+            .get_tile(tile_coordinate.x, tile_coordinate.y)
+            .unwrap();
 
         visual.set_brush(self.assets.get_color_brush_from_mine_state(mine_state))?;
         Ok(())
@@ -116,7 +124,10 @@ impl CompUI {
         self.index_helper = IndexHelper::new(grid_size_in_tiles.width, grid_size_in_tiles.height);
 
         for visual in self.game_board.tiles_iter() {
-            visual.set_brush(self.assets.get_color_brush_from_mine_state(MineState::Empty))?;
+            visual.set_brush(
+                self.assets
+                    .get_color_brush_from_mine_state(MineState::Empty),
+            )?;
         }
 
         self.update_board_scale(&self.parent_size.clone())?;
@@ -128,23 +139,21 @@ impl CompUI {
     pub fn update_tile_as_mine(&self, tile_coordinate: &TileCoordinate) -> winrt::Result<()> {
         let visual = self
             .game_board
-            .get_tile(
-                tile_coordinate.x,
-                tile_coordinate.y,
-            )
+            .get_tile(tile_coordinate.x, tile_coordinate.y)
             .unwrap();
 
         visual.set_brush(&self.assets.get_mine_brush())?;
         Ok(())
     }
 
-    pub fn update_tile_with_mine_count(&self, tile_coordinate: &TileCoordinate, num_mines: i32) -> winrt::Result<()> {
+    pub fn update_tile_with_mine_count(
+        &self,
+        tile_coordinate: &TileCoordinate,
+        num_mines: i32,
+    ) -> winrt::Result<()> {
         let visual = self
             .game_board
-            .get_tile(
-                tile_coordinate.x,
-                tile_coordinate.y,
-            )
+            .get_tile(tile_coordinate.x, tile_coordinate.y)
             .unwrap();
         visual.set_brush(self.assets.get_color_brush_from_mine_count(num_mines))?;
 
@@ -160,11 +169,15 @@ impl CompUI {
         Ok(())
     }
 
-    pub fn play_mine_animations(&mut self, mut mine_indices: VecDeque<usize>, mut mines_per_ring: VecDeque<i32>) -> winrt::Result<()> {
+    pub fn play_mine_animations(
+        &mut self,
+        mut mine_indices: VecDeque<usize>,
+        mut mines_per_ring: VecDeque<i32>,
+    ) -> winrt::Result<()> {
         // Create an animation batch so that we can know when the animations complete
         let batch = self
-                            .compositor
-                            .create_scoped_batch(CompositionBatchTypes::Animation)?;
+            .compositor
+            .create_scoped_batch(CompositionBatchTypes::Animation)?;
 
         let animation_delay_step = Duration::from_millis(100);
         let mut current_delay = Duration::from_millis(0);

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ winrt::import!(
 );
 
 mod comp_assets;
+mod comp_ui;
 mod interop;
 mod minesweeper;
 mod numerics;

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod interop;
 mod minesweeper;
 mod numerics;
 mod time_span;
+mod visual_grid;
 mod window_target;
 
 use interop::{create_dispatcher_queue_controller_for_current_thread, ro_initialize, RoInitType};

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ winrt::import!(
         "windows.system"
 );
 
+mod comp_assets;
 mod interop;
 mod minesweeper;
 mod numerics;

--- a/src/minesweeper.rs
+++ b/src/minesweeper.rs
@@ -1,22 +1,12 @@
-use crate::comp_assets::CompAssets;
-use crate::visual_grid::VisualGrid;
+use crate::comp_ui::CompUI;
+use crate::visual_grid::TileCoordinate;
 use crate::windows::{
-    foundation::{
-        numerics::{Vector2, Vector3},
-        TimeSpan,
-    },
+    foundation::numerics::Vector2,
     graphics::SizeInt32,
-    ui::{
-        composition::{
-            AnimationIterationBehavior, CompositionBatchTypes, CompositionBorderMode,
-            Compositor, ContainerVisual, SpriteVisual,
-        },
-        Colors,
-    },
+    ui::composition::ContainerVisual,
 };
 use rand::distributions::{Distribution, Uniform};
 use std::collections::VecDeque;
-use std::time::Duration;
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub enum MineState {
@@ -42,86 +32,74 @@ enum MineGenerationState {
     Generated,
 }
 
-pub struct Minesweeper {
-    compositor: Compositor,
-    _root: SpriteVisual,
+pub struct IndexHelper {
+    width: i32,
+    height: i32,
+}
 
-    game_board: VisualGrid,
+impl IndexHelper {
+    pub fn new(width: i32, height: i32) -> Self {
+        Self {
+            width: width,
+            height: height,
+        }
+    }
+
+    pub fn compute_index(&self, x: i32, y: i32) -> usize {
+        (x * self.height + y) as usize
+    }
+
+    pub fn compute_x_from_index(&self, index: usize) -> i32 {
+        index as i32 / self.height
+    }
+
+    pub fn compute_y_from_index(&self, index: usize) -> i32 {
+        index as i32 % self.height
+    }
+
+    pub fn is_in_bounds(&self, x: i32, y: i32) -> bool {
+        (x >= 0 && x < self.width) && (y >= 0 && y < self.height)
+    }
+}
+
+pub struct Minesweeper {
+    ui: CompUI,
 
     game_board_width: i32,
     game_board_height: i32,
-    game_board_margin: Vector2,
+    index_helper: IndexHelper,
 
     mine_states: Vec<MineState>,
     mines: Vec<bool>,
     neighbor_counts: Vec<i32>,
-    parent_size: Vector2,
     mine_generation_state: MineGenerationState,
     num_mines: i32,
 
-    mine_animation_playing: bool,
     game_over: bool,
-
-    assets: CompAssets,
 }
 
 impl Minesweeper {
     pub fn new(parent_visual: &ContainerVisual, parent_size: &Vector2) -> winrt::Result<Self> {
-        let compositor = parent_visual.compositor()?;
-        let root = compositor.create_sprite_visual()?;
-
-        root.set_relative_size_adjustment(Vector2 { x: 1.0, y: 1.0 })?;
-        root.set_brush(compositor.create_color_brush_with_color(Colors::white()?)?)?;
-        root.set_border_mode(CompositionBorderMode::Hard)?;
-        parent_visual.children()?.insert_at_top(&root)?;
-
-        let tile_size = Vector2 { x: 25.0, y: 25.0 };
-        let game_board = VisualGrid::new(
-            &compositor,
-            &SizeInt32 {
-                width: 16,
-                height: 16,
-            },
-            &tile_size,
-            &Vector2 { x: 2.5, y: 2.5 },
-        )?;
-        let game_board_margin = Vector2 { x: 100.0, y: 100.0 };
-
-        let game_board_visual = game_board.root();
-        game_board_visual.set_relative_offset_adjustment(Vector3 {
-            x: 0.5,
-            y: 0.5,
-            z: 0.0,
-        })?;
-        game_board_visual.set_anchor_point(Vector2 { x: 0.5, y: 0.5 })?;
-        root.children()?.insert_at_top(game_board_visual)?;
-
-        let selection_visual = game_board.selection_visual();
-        root.children()?.insert_at_top(selection_visual)?;
-
-        let assets = CompAssets::new(&compositor, &tile_size)?;
+        let game_board_size_in_tiles = SizeInt32 {
+            width: 16,
+            height: 16,
+        };
+        let ui = CompUI::new(parent_visual, parent_size, &game_board_size_in_tiles)?;
 
         let mut result = Self {
-            compositor: compositor,
-            _root: root,
+            ui: ui,
 
-            game_board: game_board,
-
-            game_board_width: 0,
-            game_board_height: 0,
-            game_board_margin: game_board_margin,
+            game_board_width: game_board_size_in_tiles.width,
+            game_board_height: game_board_size_in_tiles.height,
+            index_helper: IndexHelper::new(game_board_size_in_tiles.width, game_board_size_in_tiles.height),
 
             mine_states: Vec::new(),
             mines: Vec::new(),
             neighbor_counts: Vec::new(),
-            parent_size: parent_size.clone(),
             mine_generation_state: MineGenerationState::Deferred,
             num_mines: 0,
 
-            mine_animation_playing: false,
             game_over: false,
-
-            assets: assets,
         };
 
         result.new_game(16, 16, 40)?;
@@ -131,19 +109,12 @@ impl Minesweeper {
     }
 
     pub fn on_pointer_moved(&mut self, point: &Vector2) -> winrt::Result<()> {
-        if self.game_over || self.mine_animation_playing {
+        if self.game_over || self.ui.is_animation_playing() {
             return Ok(());
         }
 
-        let window_size = &self.parent_size;
-        let scale = self.compute_scale_factor()?;
-        let real_board_size = self.game_board.size()? * scale;
-        let real_offset = (window_size - real_board_size) / 2.0;
-
-        let point = (point - real_offset) / scale;
-
-        let selected_tile = if let Some(tile) = self.game_board.hit_test(&point) {
-            if self.mine_states[self.compute_index(tile.x, tile.y)] != MineState::Revealed {
+        let selected_tile = if let Some(tile) = self.ui.hit_test(&point)? {
+            if self.mine_states[self.index_helper.compute_index(tile.x, tile.y)] != MineState::Revealed {
                 Some(tile)
             } else {
                 None
@@ -151,14 +122,13 @@ impl Minesweeper {
         } else {
             None
         };
-        self.game_board.select_tile(selected_tile)?;
+        self.ui.select_tile(selected_tile)?;
 
         Ok(())
     }
 
     pub fn on_parent_size_changed(&mut self, new_size: &Vector2) -> winrt::Result<()> {
-        self.parent_size = new_size.clone();
-        self.update_board_scale(new_size)?;
+        self.ui.resize(new_size)?;
         Ok(())
     }
 
@@ -168,8 +138,8 @@ impl Minesweeper {
         is_eraser: bool,
     ) -> winrt::Result<()> {
         // TODO: Switch the condition back once we can subscribe to events.
-        //if self.game_over && !self.mine_animation_playing {
-        if self.game_over && self.mine_animation_playing {
+        //if self.game_over && !self.ui.is_animation_playing() {
+        if self.game_over && self.ui.is_animation_playing() {
             self.new_game(
                 self.game_board_width,
                 self.game_board_height,
@@ -177,40 +147,26 @@ impl Minesweeper {
             )?;
         }
 
-        let current_selection = self.game_board.current_selected_tile();
+        let current_selection = self.ui.current_selected_tile();
         if let Some(current_selection) = current_selection {
-            let index = self.compute_index(current_selection.x, current_selection.y);
-            let visual = self
-                .game_board
-                .get_tile(current_selection.x, current_selection.y)
-                .unwrap();
+            let index = self.index_helper.compute_index(current_selection.x, current_selection.y);
 
             if self.mine_states[index] != MineState::Revealed {
                 if is_right_button || is_eraser {
                     let state = self.mine_states[index].cycle();
                     self.mine_states[index] = state;
-                    visual.set_brush(self.assets.get_color_brush_from_mine_state(state))?;
+                    self.ui.update_tile_with_state(&current_selection, state)?;
                 } else if self.mine_states[index] == MineState::Empty {
                     if self.sweep(current_selection.x, current_selection.y)? {
-                        // We hit a mine! Setup and play an animation whiel locking any input.
+                        // We hit a mine! Setup and play an animation while locking any input.
                         let hit_x = current_selection.x;
                         let hit_y = current_selection.y;
 
                         // First, hide the selection visual and reset the selection
-                        self.game_board.select_tile(None)?;
-
-                        // Create an animation batch so that we can know when the animations complete
-                        let batch = self
-                            .compositor
-                            .create_scoped_batch(CompositionBatchTypes::Animation)?;
+                        self.ui.select_tile(None)?;
 
                         self.play_animation_on_all_mines(hit_x, hit_y)?;
 
-                        // Subscribe to the completion event and complete the batch
-                        // TODO: events
-                        batch.end()?;
-
-                        self.mine_animation_playing = true;
                         self.game_over = true;
                     }
                     // TODO: Detect that the player has won
@@ -223,54 +179,22 @@ impl Minesweeper {
     fn new_game(&mut self, board_width: i32, board_height: i32, mines: i32) -> winrt::Result<()> {
         self.game_board_width = board_width;
         self.game_board_height = board_height;
+        self.index_helper = IndexHelper::new(board_width, board_height);
 
-        self.game_board.reset(&SizeInt32 {
+        self.ui.reset(&SizeInt32 {
             width: board_width,
             height: board_height,
         })?;
         self.mine_states.clear();
 
-        for visual in self.game_board.tiles_iter() {
-            visual.set_brush(self.assets.get_color_brush_from_mine_state(MineState::Empty))?;
+        for _ in 0..(board_width * board_height) {
             self.mine_states.push(MineState::Empty);
         }
-
-        self.mine_animation_playing = false;
+  
         self.game_over = false;
         self.mine_generation_state = MineGenerationState::Deferred;
         self.num_mines = mines;
 
-        self.update_board_scale(&self.parent_size.clone())?;
-
-        Ok(())
-    }
-
-    fn compute_scale_factor_from_size(&self, window_size: &Vector2) -> winrt::Result<f32> {
-        let board_size = self.game_board.size()?;
-        let board_size = board_size + &self.game_board_margin;
-
-        let window_ratio = window_size.x / window_size.y;
-        let board_ratio = board_size.x / board_size.y;
-
-        let mut scale_factor = window_size.x / board_size.x;
-        if window_ratio > board_ratio {
-            scale_factor = window_size.y / board_size.y;
-        }
-
-        Ok(scale_factor)
-    }
-
-    fn compute_scale_factor(&self) -> winrt::Result<f32> {
-        self.compute_scale_factor_from_size(&self.parent_size)
-    }
-
-    fn update_board_scale(&mut self, window_size: &Vector2) -> winrt::Result<()> {
-        let scale_factor = self.compute_scale_factor_from_size(window_size)?;
-        self.game_board.root().set_scale(Vector3 {
-            x: scale_factor,
-            y: scale_factor,
-            z: 1.0,
-        })?;
         Ok(())
     }
 
@@ -284,13 +208,13 @@ impl Minesweeper {
 
         let mut hit_mine = false;
         let mut sweeps: VecDeque<usize> = VecDeque::new();
-        sweeps.push_back(self.compute_index(x, y));
+        sweeps.push_back(self.index_helper.compute_index(x, y));
         self.reveal(*sweeps.front().unwrap())?;
 
         while !sweeps.is_empty() {
             let index = *sweeps.front().unwrap();
-            let current_x = self.compute_x_from_index(index);
-            let current_y = self.compute_y_from_index(index);
+            let current_x = self.index_helper.compute_x_from_index(index);
+            let current_y = self.index_helper.compute_y_from_index(index);
 
             if self.mines[index] {
                 // We hit a mine, game over
@@ -316,28 +240,16 @@ impl Minesweeper {
     }
 
     fn reveal(&mut self, index: usize) -> winrt::Result<()> {
-        let visual = self
-            .game_board
-            .get_tile(
-                self.compute_x_from_index(index),
-                self.compute_y_from_index(index),
-            )
-            .unwrap();
+        let tile_coordinate = TileCoordinate {
+            x: self.index_helper.compute_x_from_index(index),
+            y: self.index_helper.compute_y_from_index(index),
+        };
 
         if self.mines[index] {
-            visual.set_brush(&self.assets.get_mine_brush())?;
+            self.ui.update_tile_as_mine(&tile_coordinate)?;
         } else {
             let count = self.neighbor_counts[index];
-            visual.set_brush(self.assets.get_color_brush_from_mine_count(count))?;
-
-            if count > 0 {
-                let shape = self.assets.get_shape_from_mine_count(count);
-                let shape_visual = self.compositor.create_shape_visual()?;
-                shape_visual.set_relative_size_adjustment(Vector2 { x: 1.0, y: 1.0 })?;
-                shape_visual.shapes()?.append(shape)?;
-                shape_visual.set_border_mode(CompositionBorderMode::Soft)?;
-                visual.children()?.insert_at_top(shape_visual)?;
-            }
+            self.ui.update_tile_with_mine_count(&tile_coordinate, count)?;
         }
 
         self.mine_states[index] = MineState::Revealed;
@@ -345,8 +257,8 @@ impl Minesweeper {
     }
 
     fn is_in_bounds_and_unmarked(&self, x: i32, y: i32) -> bool {
-        let index = self.compute_index(x, y);
-        self.is_in_bounds(x, y) && self.mine_states[index] == MineState::Empty
+        let index = self.index_helper.compute_index(x, y);
+        self.index_helper.is_in_bounds(x, y) && self.mine_states[index] == MineState::Empty
     }
 
     fn push_if_unmarked(
@@ -356,7 +268,7 @@ impl Minesweeper {
         y: i32,
     ) -> winrt::Result<()> {
         if self.is_in_bounds_and_unmarked(x, y) {
-            let index = self.compute_index(x, y);
+            let index = self.index_helper.compute_index(x, y);
             self.reveal(index)?;
             sweeps.push_back(index);
         }
@@ -376,7 +288,7 @@ impl Minesweeper {
         let mut rng = rand::thread_rng();
         for _i in 0..num_mines {
             let mut index: usize;
-            let exclude_index = self.compute_index(exclude_x, exclude_y);
+            let exclude_index = self.index_helper.compute_index(exclude_x, exclude_y);
             // do while loops look weird in rust...
             while {
                 index = between.sample(&mut rng);
@@ -388,8 +300,8 @@ impl Minesweeper {
 
         self.neighbor_counts.clear();
         for i in 0..self.mines.len() {
-            let x = self.compute_x_from_index(i);
-            let y = self.compute_y_from_index(i);
+            let x = self.index_helper.compute_x_from_index(i);
+            let y = self.index_helper.compute_y_from_index(i);
 
             if self.mines[i] {
                 // -1 means a mine
@@ -401,24 +313,9 @@ impl Minesweeper {
         }
     }
 
-    fn compute_index(&self, x: i32, y: i32) -> usize {
-        (x * self.game_board_height + y) as usize
-    }
-
-    fn compute_x_from_index(&self, index: usize) -> i32 {
-        index as i32 / self.game_board_height
-    }
-
-    fn compute_y_from_index(&self, index: usize) -> i32 {
-        index as i32 % self.game_board_height
-    }
-
-    fn is_in_bounds(&self, x: i32, y: i32) -> bool {
-        (x >= 0 && x < self.game_board_width) && (y >= 0 && y < self.game_board_height)
-    }
-
+    
     fn test_spot(&self, x: i32, y: i32) -> bool {
-        self.is_in_bounds(x, y) && self.mines[self.compute_index(x, y)]
+        self.index_helper.is_in_bounds(x, y) && self.mines[self.index_helper.compute_index(x, y)]
     }
 
     fn get_surrounding_mine_count(&self, x: i32, y: i32) -> i32 {
@@ -459,54 +356,6 @@ impl Minesweeper {
         count
     }
 
-    fn play_mine_animation(&self, index: usize, delay: &TimeSpan) -> winrt::Result<()> {
-        let visual = self
-            .game_board
-            .get_tile(
-                self.compute_x_from_index(index),
-                self.compute_y_from_index(index),
-            )
-            .unwrap();
-        // First, we need to promote the visual to the top.
-        let parent_children = visual.parent()?.children()?;
-        parent_children.remove(visual)?;
-        parent_children.insert_at_top(visual)?;
-        // Make sure the visual has the mine brush
-        visual.set_brush(&self.assets.get_mine_brush())?;
-        // Play the animation
-        let animation = self.compositor.create_vector3_key_frame_animation()?;
-        animation.insert_key_frame(
-            0.0,
-            Vector3 {
-                x: 1.0,
-                y: 1.0,
-                z: 1.0,
-            },
-        )?;
-        animation.insert_key_frame(
-            0.7,
-            Vector3 {
-                x: 2.0,
-                y: 2.0,
-                z: 1.0,
-            },
-        )?;
-        animation.insert_key_frame(
-            1.0,
-            Vector3 {
-                x: 1.0,
-                y: 1.0,
-                z: 1.0,
-            },
-        )?;
-        animation.set_duration(TimeSpan::from(Duration::from_millis(600)))?;
-        animation.set_delay_time(delay)?;
-        animation.set_iteration_behavior(AnimationIterationBehavior::Count)?;
-        animation.set_iteration_count(1)?;
-        visual.start_animation("Scale", animation)?;
-        Ok(())
-    }
-
     fn check_tile_for_mine_for_animation(
         &self,
         x: i32,
@@ -515,8 +364,8 @@ impl Minesweeper {
         visited_tiles: &mut i32,
         mines_in_ring: &mut i32,
     ) {
-        if self.is_in_bounds(x, y) {
-            let tile_index = self.compute_index(x, y);
+        if self.index_helper.is_in_bounds(x, y) {
+            let tile_index = self.index_helper.compute_index(x, y);
             if self.mines[tile_index] {
                 mine_indices.push_back(tile_index);
                 *mines_in_ring = *mines_in_ring + 1;
@@ -531,9 +380,9 @@ impl Minesweeper {
         let mut mines_per_ring: VecDeque<i32> = VecDeque::new();
         let mut visited_tiles: i32 = 0;
         let mut ring_level: i32 = 0;
-        while visited_tiles < self.game_board.num_tiles() as i32 {
+        while visited_tiles < (self.game_board_width * self.game_board_height) {
             if ring_level == 0 {
-                let hit_mine_index = self.compute_index(center_x, center_y);
+                let hit_mine_index = self.index_helper.compute_index(center_x, center_y);
                 mine_indices.push_back(hit_mine_index);
                 mines_per_ring.push_back(1);
                 visited_tiles = visited_tiles + 1;
@@ -596,22 +445,7 @@ impl Minesweeper {
         }
 
         // Iterate and animate each mine
-        let animation_delay_step = Duration::from_millis(100);
-        let mut current_delay = Duration::from_millis(0);
-        let mut current_mines_count = 0;
-        while !mine_indices.is_empty() {
-            let mine_index = *mine_indices.front().unwrap();
-            self.play_mine_animation(mine_index, &TimeSpan::from(current_delay))?;
-            current_mines_count = current_mines_count + 1;
-
-            let mines_on_current_level = *mines_per_ring.front().unwrap();
-            if current_mines_count == mines_on_current_level {
-                current_mines_count = 0;
-                mines_per_ring.pop_front().unwrap();
-                current_delay = current_delay + animation_delay_step;
-            }
-            mine_indices.pop_front().unwrap();
-        }
+        self.ui.play_mine_animations(mine_indices, mines_per_ring)?;
 
         Ok(())
     }

--- a/src/minesweeper.rs
+++ b/src/minesweeper.rs
@@ -1,9 +1,7 @@
 use crate::comp_ui::CompUI;
 use crate::visual_grid::TileCoordinate;
 use crate::windows::{
-    foundation::numerics::Vector2,
-    graphics::SizeInt32,
-    ui::composition::ContainerVisual,
+    foundation::numerics::Vector2, graphics::SizeInt32, ui::composition::ContainerVisual,
 };
 use rand::distributions::{Distribution, Uniform};
 use std::collections::VecDeque;
@@ -91,7 +89,10 @@ impl Minesweeper {
 
             game_board_width: game_board_size_in_tiles.width,
             game_board_height: game_board_size_in_tiles.height,
-            index_helper: IndexHelper::new(game_board_size_in_tiles.width, game_board_size_in_tiles.height),
+            index_helper: IndexHelper::new(
+                game_board_size_in_tiles.width,
+                game_board_size_in_tiles.height,
+            ),
 
             mine_states: Vec::new(),
             mines: Vec::new(),
@@ -114,7 +115,9 @@ impl Minesweeper {
         }
 
         let selected_tile = if let Some(tile) = self.ui.hit_test(&point)? {
-            if self.mine_states[self.index_helper.compute_index(tile.x, tile.y)] != MineState::Revealed {
+            if self.mine_states[self.index_helper.compute_index(tile.x, tile.y)]
+                != MineState::Revealed
+            {
                 Some(tile)
             } else {
                 None
@@ -149,7 +152,9 @@ impl Minesweeper {
 
         let current_selection = self.ui.current_selected_tile();
         if let Some(current_selection) = current_selection {
-            let index = self.index_helper.compute_index(current_selection.x, current_selection.y);
+            let index = self
+                .index_helper
+                .compute_index(current_selection.x, current_selection.y);
 
             if self.mine_states[index] != MineState::Revealed {
                 if is_right_button || is_eraser {
@@ -190,7 +195,7 @@ impl Minesweeper {
         for _ in 0..(board_width * board_height) {
             self.mine_states.push(MineState::Empty);
         }
-  
+
         self.game_over = false;
         self.mine_generation_state = MineGenerationState::Deferred;
         self.num_mines = mines;
@@ -249,7 +254,8 @@ impl Minesweeper {
             self.ui.update_tile_as_mine(&tile_coordinate)?;
         } else {
             let count = self.neighbor_counts[index];
-            self.ui.update_tile_with_mine_count(&tile_coordinate, count)?;
+            self.ui
+                .update_tile_with_mine_count(&tile_coordinate, count)?;
         }
 
         self.mine_states[index] = MineState::Revealed;
@@ -313,7 +319,6 @@ impl Minesweeper {
         }
     }
 
-    
     fn test_spot(&self, x: i32, y: i32) -> bool {
         self.index_helper.is_in_bounds(x, y) && self.mines[self.index_helper.compute_index(x, y)]
     }

--- a/src/minesweeper.rs
+++ b/src/minesweeper.rs
@@ -37,10 +37,7 @@ pub struct IndexHelper {
 
 impl IndexHelper {
     pub fn new(width: i32, height: i32) -> Self {
-        Self {
-            width,
-            height,
-        }
+        Self { width, height }
     }
 
     pub fn compute_index(&self, x: i32, y: i32) -> usize {

--- a/src/minesweeper.rs
+++ b/src/minesweeper.rs
@@ -317,7 +317,9 @@ impl Minesweeper {
                 self.neighbor_counts.push(-1);
                 // DEBUG
                 if cfg!(debug_assertions) {
-                    self.ui.update_tile_with_state(&TileCoordinate { x: x, y: y }, MineState::Question).unwrap();
+                    self.ui
+                        .update_tile_with_state(&TileCoordinate { x: x, y: y }, MineState::Question)
+                        .unwrap();
                 }
             } else {
                 let count = self.get_surrounding_mine_count(x, y);

--- a/src/minesweeper.rs
+++ b/src/minesweeper.rs
@@ -313,7 +313,7 @@ impl Minesweeper {
                 // -1 means a mine
                 self.neighbor_counts.push(-1);
                 // DEBUG
-                if cfg!(debug_assertions) {
+                if cfg!(feature = "show-mines") {
                     self.ui
                         .update_tile_with_state(&TileCoordinate { x, y }, MineState::Question)
                         .unwrap();

--- a/src/minesweeper.rs
+++ b/src/minesweeper.rs
@@ -38,8 +38,8 @@ pub struct IndexHelper {
 impl IndexHelper {
     pub fn new(width: i32, height: i32) -> Self {
         Self {
-            width: width,
-            height: height,
+            width,
+            height,
         }
     }
 
@@ -85,7 +85,7 @@ impl Minesweeper {
         let ui = CompUI::new(parent_visual, parent_size, &game_board_size_in_tiles)?;
 
         let mut result = Self {
-            ui: ui,
+            ui,
 
             game_board_width: game_board_size_in_tiles.width,
             game_board_height: game_board_size_in_tiles.height,
@@ -318,7 +318,7 @@ impl Minesweeper {
                 // DEBUG
                 if cfg!(debug_assertions) {
                     self.ui
-                        .update_tile_with_state(&TileCoordinate { x: x, y: y }, MineState::Question)
+                        .update_tile_with_state(&TileCoordinate { x, y }, MineState::Question)
                         .unwrap();
                 }
             } else {
@@ -336,35 +336,35 @@ impl Minesweeper {
         let mut count = 0;
 
         if self.test_spot(x + 1, y) {
-            count = count + 1;
+            count += 1;
         }
 
         if self.test_spot(x - 1, y) {
-            count = count + 1;
+            count += 1;
         }
 
         if self.test_spot(x, y + 1) {
-            count = count + 1;
+            count += 1;
         }
 
         if self.test_spot(x, y - 1) {
-            count = count + 1;
+            count += 1;
         }
 
         if self.test_spot(x + 1, y + 1) {
-            count = count + 1;
+            count += 1;
         }
 
         if self.test_spot(x - 1, y - 1) {
-            count = count + 1;
+            count += 1;
         }
 
         if self.test_spot(x - 1, y + 1) {
-            count = count + 1;
+            count += 1;
         }
 
         if self.test_spot(x + 1, y - 1) {
-            count = count + 1;
+            count += 1;
         }
 
         count
@@ -382,9 +382,9 @@ impl Minesweeper {
             let tile_index = self.index_helper.compute_index(x, y);
             if self.mines[tile_index] {
                 mine_indices.push_back(tile_index);
-                *mines_in_ring = *mines_in_ring + 1;
+                *mines_in_ring += 1;
             }
-            *visited_tiles = *visited_tiles + 1;
+            *visited_tiles += 1;
         }
     }
 
@@ -399,7 +399,7 @@ impl Minesweeper {
                 let hit_mine_index = self.index_helper.compute_index(center_x, center_y);
                 mine_indices.push_back(hit_mine_index);
                 mines_per_ring.push_back(1);
-                visited_tiles = visited_tiles + 1;
+                visited_tiles += 1;
             } else {
                 let mut current_mines_in_ring = 0;
 
@@ -455,7 +455,7 @@ impl Minesweeper {
                     mines_per_ring.push_back(current_mines_in_ring);
                 }
             }
-            ring_level = ring_level + 1;
+            ring_level += 1;
         }
 
         // Iterate and animate each mine

--- a/src/numerics.rs
+++ b/src/numerics.rs
@@ -146,7 +146,7 @@ impl FromVector2 for Vector3 {
         Vector3 {
             x: value.x,
             y: value.y,
-            z: z,
+            z,
         }
     }
 }

--- a/src/visual_grid.rs
+++ b/src/visual_grid.rs
@@ -1,0 +1,176 @@
+use crate::numerics::FromVector2;
+use crate::windows::{
+    foundation::numerics::{Vector2, Vector3},
+    graphics::SizeInt32,
+    ui::{
+        composition::{Compositor, ContainerVisual, SpriteVisual},
+        Colors,
+    },
+};
+
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub struct TileCoordinate {
+    pub x: i32,
+    pub y: i32,
+}
+
+pub struct VisualGrid {
+    compositor: Compositor,
+    root: ContainerVisual,
+
+    tiles: Vec<SpriteVisual>,
+    selection_visual: SpriteVisual,
+
+    grid_width_in_tiles: i32,
+    grid_height_in_tiles: i32,
+    tile_size: Vector2,
+    margin: Vector2,
+
+    current_selection: Option<TileCoordinate>,
+}
+
+impl VisualGrid {
+    pub fn new(
+        compositor: &Compositor,
+        grid_size_in_tiles: &SizeInt32,
+        tile_size: &Vector2,
+        margin: &Vector2,
+    ) -> winrt::Result<Self> {
+        let compositor = compositor.clone();
+        let root = compositor.create_container_visual()?;
+
+        let selection_visual = compositor.create_sprite_visual()?;
+        let color_brush = compositor.create_color_brush_with_color(Colors::red()?)?;
+        let nine_grid_brush = compositor.create_nine_grid_brush()?;
+        nine_grid_brush.set_insets_with_values(margin.x, margin.y, margin.x, margin.y)?;
+        nine_grid_brush.set_is_center_hollow(true)?;
+        nine_grid_brush.set_source(color_brush)?;
+        selection_visual.set_brush(nine_grid_brush)?;
+        selection_visual.set_offset(Vector3::from_vector2(margin * -1.0, 0.0))?;
+        selection_visual.set_is_visible(false)?;
+        selection_visual.set_size(tile_size + margin * 2.0)?;
+
+        let mut result = Self {
+            compositor: compositor,
+            root: root,
+
+            tiles: Vec::new(),
+            selection_visual: selection_visual,
+
+            grid_width_in_tiles: grid_size_in_tiles.width,
+            grid_height_in_tiles: grid_size_in_tiles.height,
+            tile_size: tile_size.clone(),
+            margin: margin.clone(),
+
+            current_selection: None,
+        };
+
+        result.reset(grid_size_in_tiles)?;
+
+        Ok(result)
+    }
+
+    pub fn reset(&mut self, grid_size_in_tiles: &SizeInt32) -> winrt::Result<()> {
+        let children = self.root.children()?;
+        children.remove_all()?;
+        self.tiles.clear();
+
+        self.grid_width_in_tiles = grid_size_in_tiles.width;
+        self.grid_height_in_tiles = grid_size_in_tiles.height;
+        self.select_tile(None)?;
+
+        self.root.set_size(
+            (&self.tile_size + &self.margin)
+                * Vector2 {
+                    x: self.grid_width_in_tiles as f32,
+                    y: self.grid_height_in_tiles as f32,
+                },
+        )?;
+
+        for x in 0..self.grid_width_in_tiles {
+            for y in 0..self.grid_height_in_tiles {
+                let visual = self.compositor.create_sprite_visual()?;
+                visual.set_size(&self.tile_size)?;
+                visual.set_center_point(Vector3::from_vector2(&self.tile_size / 2.0, 0.0))?;
+                visual.set_offset(Vector3::from_vector2(
+                    (&self.margin / 2.0)
+                        + ((&self.tile_size + &self.margin)
+                            * Vector2 {
+                                x: x as f32,
+                                y: y as f32,
+                            }),
+                    0.0,
+                ))?;
+
+                children.insert_at_top(&visual)?;
+                self.tiles.push(visual);
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn tiles_iter(&self) -> impl std::iter::Iterator<Item = &SpriteVisual> {
+        self.tiles.iter()
+    }
+
+    pub fn root(&self) -> &ContainerVisual {
+        &self.root
+    }
+
+    pub fn selection_visual(&self) -> &SpriteVisual {
+        &self.selection_visual
+    }
+
+    pub fn size(&self) -> winrt::Result<Vector2> {
+        self.root.size()
+    }
+
+    pub fn hit_test(&self, point: &Vector2) -> Option<TileCoordinate> {
+        let x = (point.x / (self.tile_size.x + self.margin.x)) as i32;
+        let y = (point.y / (self.tile_size.y + self.margin.y)) as i32;
+
+        if self.is_in_bounds(x, y) {
+            Some(TileCoordinate { x: x, y: y })
+        } else {
+            None
+        }
+    }
+
+    pub fn get_tile(&self, x: i32, y: i32) -> Option<&SpriteVisual> {
+        if self.is_in_bounds(x, y) {
+            Some(&self.tiles[self.compute_index(x, y)])
+        } else {
+            None
+        }
+    }
+
+    pub fn select_tile(&mut self, tile_coordinate: Option<TileCoordinate>) -> winrt::Result<()> {
+        self.current_selection = tile_coordinate;
+        if let Some(tile_coordinate) = tile_coordinate {
+            let visual = &self.tiles[self.compute_index(tile_coordinate.x, tile_coordinate.y)];
+            self.selection_visual.set_parent_for_transform(visual)?;
+            self.selection_visual.set_is_visible(true)?;
+        } else {
+            self.selection_visual.set_is_visible(false)?;
+        }
+
+        Ok(())
+    }
+
+    pub fn current_selected_tile(&self) -> Option<TileCoordinate> {
+        self.current_selection
+    }
+
+    pub fn num_tiles(&self) -> usize {
+        self.tiles.len()
+    }
+
+    fn compute_index(&self, x: i32, y: i32) -> usize {
+        (x * self.grid_height_in_tiles + y) as usize
+    }
+
+    fn is_in_bounds(&self, x: i32, y: i32) -> bool {
+        (x >= 0 && x < self.grid_width_in_tiles) && (y >= 0 && y < self.grid_height_in_tiles)
+    }
+}

--- a/src/visual_grid.rs
+++ b/src/visual_grid.rs
@@ -1,4 +1,5 @@
 use crate::numerics::FromVector2;
+use crate::minesweeper::IndexHelper;
 use crate::windows::{
     foundation::numerics::{Vector2, Vector3},
     graphics::SizeInt32,
@@ -20,6 +21,7 @@ pub struct VisualGrid {
 
     tiles: Vec<SpriteVisual>,
     selection_visual: SpriteVisual,
+    index_helper: IndexHelper,
 
     grid_width_in_tiles: i32,
     grid_height_in_tiles: i32,
@@ -56,6 +58,7 @@ impl VisualGrid {
 
             tiles: Vec::new(),
             selection_visual,
+            index_helper: IndexHelper::new(grid_size_in_tiles.width, grid_size_in_tiles.height),
 
             grid_width_in_tiles: grid_size_in_tiles.width,
             grid_height_in_tiles: grid_size_in_tiles.height,
@@ -74,6 +77,8 @@ impl VisualGrid {
         let children = self.root.children()?;
         children.remove_all()?;
         self.tiles.clear();
+
+        self.index_helper = IndexHelper::new(grid_size_in_tiles.width, grid_size_in_tiles.height);
 
         self.grid_width_in_tiles = grid_size_in_tiles.width;
         self.grid_height_in_tiles = grid_size_in_tiles.height;
@@ -130,7 +135,7 @@ impl VisualGrid {
         let x = (point.x / (self.tile_size.x + self.margin.x)) as i32;
         let y = (point.y / (self.tile_size.y + self.margin.y)) as i32;
 
-        if self.is_in_bounds(x, y) {
+        if self.index_helper.is_in_bounds(x, y) {
             Some(TileCoordinate { x, y })
         } else {
             None
@@ -138,8 +143,8 @@ impl VisualGrid {
     }
 
     pub fn get_tile(&self, x: i32, y: i32) -> Option<&SpriteVisual> {
-        if self.is_in_bounds(x, y) {
-            Some(&self.tiles[self.compute_index(x, y)])
+        if self.index_helper.is_in_bounds(x, y) {
+            Some(&self.tiles[self.index_helper.compute_index(x, y)])
         } else {
             None
         }
@@ -148,7 +153,7 @@ impl VisualGrid {
     pub fn select_tile(&mut self, tile_coordinate: Option<TileCoordinate>) -> winrt::Result<()> {
         self.current_selection = tile_coordinate;
         if let Some(tile_coordinate) = tile_coordinate {
-            let visual = &self.tiles[self.compute_index(tile_coordinate.x, tile_coordinate.y)];
+            let visual = &self.tiles[self.index_helper.compute_index(tile_coordinate.x, tile_coordinate.y)];
             self.selection_visual.set_parent_for_transform(visual)?;
             self.selection_visual.set_is_visible(true)?;
         } else {
@@ -160,13 +165,5 @@ impl VisualGrid {
 
     pub fn current_selected_tile(&self) -> Option<TileCoordinate> {
         self.current_selection
-    }
-
-    fn compute_index(&self, x: i32, y: i32) -> usize {
-        (x * self.grid_height_in_tiles + y) as usize
-    }
-
-    fn is_in_bounds(&self, x: i32, y: i32) -> bool {
-        (x >= 0 && x < self.grid_width_in_tiles) && (y >= 0 && y < self.grid_height_in_tiles)
     }
 }

--- a/src/visual_grid.rs
+++ b/src/visual_grid.rs
@@ -51,11 +51,11 @@ impl VisualGrid {
         selection_visual.set_size(tile_size + margin * 2.0)?;
 
         let mut result = Self {
-            compositor: compositor,
-            root: root,
+            compositor,
+            root,
 
             tiles: Vec::new(),
-            selection_visual: selection_visual,
+            selection_visual,
 
             grid_width_in_tiles: grid_size_in_tiles.width,
             grid_height_in_tiles: grid_size_in_tiles.height,
@@ -131,7 +131,7 @@ impl VisualGrid {
         let y = (point.y / (self.tile_size.y + self.margin.y)) as i32;
 
         if self.is_in_bounds(x, y) {
-            Some(TileCoordinate { x: x, y: y })
+            Some(TileCoordinate { x, y })
         } else {
             None
         }

--- a/src/visual_grid.rs
+++ b/src/visual_grid.rs
@@ -162,10 +162,6 @@ impl VisualGrid {
         self.current_selection
     }
 
-    pub fn num_tiles(&self) -> usize {
-        self.tiles.len()
-    }
-
     fn compute_index(&self, x: i32, y: i32) -> usize {
         (x * self.grid_height_in_tiles + y) as usize
     }

--- a/src/visual_grid.rs
+++ b/src/visual_grid.rs
@@ -1,5 +1,5 @@
-use crate::numerics::FromVector2;
 use crate::minesweeper::IndexHelper;
+use crate::numerics::FromVector2;
 use crate::windows::{
     foundation::numerics::{Vector2, Vector3},
     graphics::SizeInt32,
@@ -153,7 +153,9 @@ impl VisualGrid {
     pub fn select_tile(&mut self, tile_coordinate: Option<TileCoordinate>) -> winrt::Result<()> {
         self.current_selection = tile_coordinate;
         if let Some(tile_coordinate) = tile_coordinate {
-            let visual = &self.tiles[self.index_helper.compute_index(tile_coordinate.x, tile_coordinate.y)];
+            let visual = &self.tiles[self
+                .index_helper
+                .compute_index(tile_coordinate.x, tile_coordinate.y)];
             self.selection_visual.set_parent_for_transform(visual)?;
             self.selection_visual.set_is_visible(true)?;
         } else {


### PR DESCRIPTION
This change splits the logic of the game from the UI. This came out of looking at robmikh/Minesweeper#1 and wanting to invert it. Turns out it was easier to refactor the Rust version and port the result to C++ afterwards.

There's still some simplifications that can be made, but it's sufficient to merge in.