### PR TITLE
Suppress creation of an explicit console window

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![windows_subsystem = "windows"]
+
 mod comp_assets;
 mod comp_ui;
 mod interop;


### PR DESCRIPTION
When you run the program, it creates both the main play area, and a console window when the executable is double-clicked.  The attribute `#![windows_subsystem = "windows"]` suppresses this extra console window, and was added to `main.rs`.

This attribute was introduced in [Rust 1.18](https://blog.rust-lang.org/2017/06/08/Rust-1.18.html) and called out in its release notes.