### PR TITLE
Update to `windows` 0.46

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,18 +77,18 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "windows"
-version = "0.44.0"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e745dab35a0c4c77aa3ce42d595e13d2003d6902d6b08c9ef5fc326d08da12b"
+checksum = "cdacb41e6a96a052c6cb63a144f24900236121c6f63f4f8219fef5977ecb0c25"
 dependencies = [
  "windows-targets",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -101,42 +101,42 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 rand = "0.8.5"
 
 [dependencies.windows]
-version = "0.44.0"
+version = "0.46.0"
 features = [
     "Foundation_Collections",
     "Foundation_Numerics",

--- a/src/comp_assets.rs
+++ b/src/comp_assets.rs
@@ -1,7 +1,7 @@
 use crate::minesweeper::MineState;
 use std::collections::HashMap;
 use windows::{
-    core::{Interface, Result},
+    core::{ComInterface, Result},
     Foundation::Numerics::Vector2,
     UI::{
         Colors,

--- a/src/comp_ui.rs
+++ b/src/comp_ui.rs
@@ -3,9 +3,8 @@ use crate::minesweeper::{IndexHelper, MineState};
 use crate::visual_grid::{TileCoordinate, VisualGrid};
 use std::collections::VecDeque;
 use std::time::Duration;
-use windows::h;
 use windows::{
-    core::Result,
+    core::{h, Result},
     Foundation::{
         Numerics::{Vector2, Vector3},
         TimeSpan,

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,8 +1,7 @@
 use std::sync::Once;
 
 use windows::{
-    core::{Interface, Result, HSTRING, PCWSTR},
-    w,
+    core::{w, ComInterface, Result, HSTRING, PCWSTR},
     Foundation::Numerics::Vector2,
     Graphics::SizeInt32,
     Win32::{
@@ -36,15 +35,13 @@ impl Window {
             let class = WNDCLASSW {
                 hCursor: unsafe { LoadCursorW(HINSTANCE(0), IDC_ARROW).ok().unwrap() },
                 hInstance: instance,
-                lpszClassName: WINDOW_CLASS_NAME.into(),
+                lpszClassName: WINDOW_CLASS_NAME,
                 lpfnWndProc: Some(Self::wnd_proc),
                 ..Default::default()
             };
             assert_ne!(unsafe { RegisterClassW(&class) }, 0);
         });
 
-        let width = width as i32;
-        let height = height as i32;
         let window_ex_style = WS_EX_NOREDIRECTIONBITMAP;
         let window_style = WS_OVERLAPPEDWINDOW;
 


### PR DESCRIPTION
Mainly, the `ComInterface` trait is required for `cast` (https://github.com/microsoft/windows-rs/pull/2360). Also fixed a few minor `clippy` issues. 