### PR TITLE
Update Windows dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
- "windows-targets 0.52.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -38,6 +38,8 @@ version = "0.1.0"
 dependencies = [
  "rand",
  "windows",
+ "windows-future",
+ "windows-numerics",
 ]
 
 [[package]]
@@ -123,25 +125,47 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.59.0"
+version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f919aee0a93304be7f62e8e5027811bbba96bcb1de84d6618be56e43f8a32a1"
+checksum = "ddf874e74c7a99773e62b1c671427abf01a425e77c3d3fb9fb1e4883ea934529"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-link",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5467f79cc1ba3f52ebb2ed41dbb459b8e7db636cc3429458d9a852e15bc24dec"
 dependencies = [
  "windows-core",
- "windows-targets 0.53.0",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.59.0"
+version = "0.60.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "810ce18ed2112484b0d4e15d022e5f598113e220c53e373fb31e67e21670c1ce"
+checksum = "ca21a92a9cae9bf4ccae5cf8368dce0837100ddf6e6d57936749e85f152f6247"
 dependencies = [
  "windows-implement",
  "windows-interface",
+ "windows-link",
  "windows-result",
  "windows-strings",
- "windows-targets 0.53.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a787db4595e7eb80239b74ce8babfb1363d8e343ab072f2ffe901400c03349f0"
+dependencies = [
+ "windows-core",
+ "windows-link",
 ]
 
 [[package]]
@@ -167,21 +191,37 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-result"
-version = "0.3.0"
+name = "windows-link"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d08106ce80268c4067c0571ca55a9b4e9516518eaa1a1fe9b37ca403ae1d1a34"
+checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
+
+[[package]]
+name = "windows-numerics"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "005dea54e2f6499f2cee279b8f703b3cf3b5734a2d8d21867c8f44003182eeed"
 dependencies = [
- "windows-targets 0.53.0",
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06374efe858fab7e4f881500e6e86ec8bc28f9462c47e5a9941a0142ad86b189"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b888f919960b42ea4e11c2f408fadb55f78a9f236d5eef084103c8ce52893491"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
 dependencies = [
- "windows-targets 0.53.0",
+ "windows-link",
 ]
 
 [[package]]
@@ -190,30 +230,14 @@ version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.5",
- "windows_aarch64_msvc 0.52.5",
- "windows_i686_gnu 0.52.5",
- "windows_i686_gnullvm 0.52.5",
- "windows_i686_msvc 0.52.5",
- "windows_x86_64_gnu 0.52.5",
- "windows_x86_64_gnullvm 0.52.5",
- "windows_x86_64_msvc 0.52.5",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
-dependencies = [
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -223,22 +247,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -247,22 +259,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -271,22 +271,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -295,22 +283,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,19 +6,17 @@ edition = "2021"
 
 [dependencies]
 rand = "0.9"
+windows-numerics = "0.1"
+windows-future = "0.1"
 
 [dependencies.windows]
-version = "0.59.0"
+version = "0.60.0"
 features = [
-    "Foundation_Collections",
-    "Foundation_Numerics",
     "Graphics",
     "System",
     "UI_Composition_Desktop",
-    "Win32_Foundation",
     "Win32_Graphics_Gdi",
     "Win32_System_LibraryLoader",
-    "Win32_System_WinRT",
     "Win32_System_WinRT_Composition",
     "Win32_UI_WindowsAndMessaging",
 ]

--- a/src/comp_assets.rs
+++ b/src/comp_assets.rs
@@ -2,7 +2,6 @@ use crate::minesweeper::MineState;
 use std::collections::HashMap;
 use windows::{
     core::{Interface, Result},
-    Foundation::Numerics::Vector2,
     UI::{
         Colors,
         Composition::{
@@ -11,6 +10,7 @@ use windows::{
         },
     },
 };
+use windows_numerics::Vector2;
 
 fn get_dot_shape(
     compositor: &Compositor,

--- a/src/comp_ui.rs
+++ b/src/comp_ui.rs
@@ -5,10 +5,7 @@ use std::collections::VecDeque;
 use std::time::Duration;
 use windows::{
     core::{h, Result},
-    Foundation::{
-        Numerics::{Vector2, Vector3},
-        TimeSpan,
-    },
+    Foundation::TimeSpan,
     Graphics::SizeInt32,
     UI::{
         Colors,
@@ -18,6 +15,7 @@ use windows::{
         },
     },
 };
+use windows_numerics::{Vector2, Vector3};
 
 pub struct CompUI {
     compositor: Compositor,

--- a/src/interop.rs
+++ b/src/interop.rs
@@ -1,6 +1,5 @@
 use windows::{
     core::Result,
-    Foundation::AsyncActionCompletedHandler,
     System::DispatcherQueueController,
     Win32::{
         System::WinRT::{
@@ -13,6 +12,7 @@ use windows::{
         },
     },
 };
+use windows_future::AsyncActionCompletedHandler;
 
 pub fn create_dispatcher_queue_controller(
     thread_type: DISPATCHERQUEUE_THREAD_TYPE,

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,16 +14,15 @@ use interop::{
 };
 use minesweeper::Minesweeper;
 use window::Window;
-
 use windows::{
     core::Result,
-    Foundation::Numerics::Vector2,
     Win32::{
         System::WinRT::{RoInitialize, RO_INIT_SINGLETHREADED},
         UI::WindowsAndMessaging::{DispatchMessageW, GetMessageW, TranslateMessage, MSG},
     },
     UI::Composition::Compositor,
 };
+use windows_numerics::Vector2;
 
 fn run() -> Result<()> {
     unsafe { RoInitialize(RO_INIT_SINGLETHREADED)? };

--- a/src/minesweeper.rs
+++ b/src/minesweeper.rs
@@ -2,10 +2,8 @@ use crate::comp_ui::CompUI;
 use crate::visual_grid::TileCoordinate;
 use rand::distr::{Distribution, Uniform};
 use std::collections::VecDeque;
-use windows::{
-    core::Result, Foundation::Numerics::Vector2, Graphics::SizeInt32,
-    UI::Composition::ContainerVisual,
-};
+use windows::{core::Result, Graphics::SizeInt32, UI::Composition::ContainerVisual};
+use windows_numerics::Vector2;
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub enum MineState {

--- a/src/numerics.rs
+++ b/src/numerics.rs
@@ -1,4 +1,4 @@
-use windows::Foundation::Numerics::{Vector2, Vector3};
+use windows_numerics::{Vector2, Vector3};
 
 pub trait FromVector2 {
     type Output;

--- a/src/visual_grid.rs
+++ b/src/visual_grid.rs
@@ -2,13 +2,13 @@ use crate::minesweeper::IndexHelper;
 use crate::numerics::FromVector2;
 use windows::{
     core::Result,
-    Foundation::Numerics::{Vector2, Vector3},
     Graphics::SizeInt32,
     UI::{
         Colors,
         Composition::{Compositor, ContainerVisual, SpriteVisual},
     },
 };
+use windows_numerics::{Vector2, Vector3};
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub struct TileCoordinate {

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,8 +1,6 @@
 use std::sync::Once;
-
 use windows::{
     core::{w, Interface, Result, HSTRING, PCWSTR},
-    Foundation::Numerics::Vector2,
     Graphics::SizeInt32,
     Win32::{
         Foundation::{HINSTANCE, HWND, LPARAM, LRESULT, RECT, WPARAM},
@@ -17,6 +15,7 @@ use windows::{
     },
     UI::Composition::{Compositor, Desktop::DesktopWindowTarget},
 };
+use windows_numerics::Vector2;
 
 use crate::minesweeper::Minesweeper;
 


### PR DESCRIPTION
This update picks up `windows 0.60` as well as the new dedicated `windows-numerics` and `windows-future` crates. 